### PR TITLE
Fix copy-pasta error in FsHtml.fs around headings

### DIFF
--- a/src/FsHtml.fs
+++ b/src/FsHtml.fs
@@ -54,9 +54,9 @@ let th = elem "th"
 let ul = elem "ul"
 let li = elem "li"
 let h1 = elem "h1"
-let h2 = elem "h1"
-let h3 = elem "h1"
-let h4 = elem "h1"
+let h2 = elem "h2"
+let h3 = elem "h3"
+let h4 = elem "h4"
 let strong = elem "strong"
 let (~%) s = [Text(s.ToString())]
 let (%=) name value = Attr(name,value)


### PR DESCRIPTION
The functions for h2, h3 and h4 all created an <h1> element
